### PR TITLE
Specify lowest supported cryptography version rather than exact version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-cryptography==1.0.2
+cryptography>=0.9.3

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def parse_requirements(requirements):
         return [l.strip('\n') for l in f if l.strip('\n') and not l.startswith('#')]
 
 
-version = '0.1.4'
+version = '0.1.5'
 requirements = parse_requirements('requirements.txt')
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:


### PR DESCRIPTION
Packages should specify the lowest supported version for dependencies to prevent version conflicts.

Specifying cryptography 0.9.3 because this is the latest conda release. Verified that waterbutler and osf work with this version.
